### PR TITLE
Fix invisible overlay blocking menu/lobby clicks

### DIFF
--- a/Scripts/Game/UI/HUD/GRAD_BC_Gamestate/GRAD_BC_Gamestate.c
+++ b/Scripts/Game/UI/HUD/GRAD_BC_Gamestate/GRAD_BC_Gamestate.c
@@ -20,6 +20,9 @@ class GRAD_BC_Gamestate: SCR_InfoDisplayExtended
 			PrintFormat("GRAD_BC_Gamestate: no m_text found", LogLevel.ERROR);
 			return;
 		}
+
+		// Hide initially to prevent blocking input in menu/lobby
+		HideLogo();
 	}
 	
 	void ShowText(string message)


### PR DESCRIPTION
The GRAD_BC_Gamestate widget uses an OverlayWidgetClass that was created
during DisplayInit but never explicitly hidden. This caused the overlay
to block input in the main menu and lobby screens.

Added HideLogo() call at the end of DisplayInit to ensure the widget
starts hidden, matching the pattern used in GRAD_BC_Logo.c.

https://claude.ai/code/session_014ryiHpdUcwQ33fTJG8pXYV